### PR TITLE
Use dynamic arrays for N-gram state

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Run the simulator and adjust parameters using command line flags:
 - `--rounds R`   – number of rounds per match (default: 200)
 - `--seed S`     – RNG seed (default: 1234567)
 - `--p-ngram F`  – fraction of agents using the N-gram strategy (default: 0.5)
-- `--depth D`    – N-gram history depth, up to 3 (default: 3)
+- `--depth D`    – N-gram history depth (default: 3)
 - `--epsilon E`  – exploration rate for N-gram learners (default: 0.1)
 - `--gtft P`     – forgiveness probability for Generous Tit for Tat (default: 0.1)
 


### PR DESCRIPTION
## Summary
- Replace fixed PlayerState arrays with dynamically allocated storage sized to `1 << (2 * depth)`.
- Update N-gram choice and update logic to index new arrays and free memory when done.
- Remove depth cap in configuration and docs.

## Testing
- `nvcc -O3 -arch=sm_86 damnati.cu -o damnati` *(fails: nvcc not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c7077bece88328b07f00ebea1ca85a