### PR TITLE
Clamp epsilon and GTFT probabilities

### DIFF
--- a/damnati.cu
+++ b/damnati.cu
@@ -314,6 +314,8 @@ void parse_cli(int argc, char **argv, Config &cfg) {
     }
   }
   cfg.p_ngram = dclamp(cfg.p_ngram, 0.0f, 1.0f);
+  cfg.epsilon = dclamp(cfg.epsilon, 0.0f, 1.0f);
+  cfg.gtft_p  = dclamp(cfg.gtft_p, 0.0f, 1.0f);
   cfg.depth = dmax(0, cfg.depth);
 }
 


### PR DESCRIPTION
## Summary
- Clamp `epsilon` and `gtft_p` configuration values within valid range in CLI parser.

## Testing
- `nvcc -O3 -arch=sm_86 damnati.cu -o damnati`


------
https://chatgpt.com/codex/tasks/task_e_68c73cc35e8c8328b3287dd5bf07fd20