### PR TITLE
Remove unused n-gram cleanup

### DIFF
--- a/damnati.cu
+++ b/damnati.cu
@@ -111,8 +111,6 @@ struct PlayerState {
       q[i] = 0.0f;
     }
   }
-
-  __device__ __forceinline__ void free_ngram() {}
 };
 
 __device__ __forceinline__ int encode_pair(int my, int opp) {
@@ -242,11 +240,6 @@ __global__ void play_all_pairs(const AgentParams *__restrict__ params,
 
   atomicAdd(&scores[i], scoreA);
   atomicAdd(&scores[j], scoreB);
-
-  if (A.strat == NGRAM)
-    A.free_ngram();
-  if (B.strat == NGRAM)
-    B.free_ngram();
 }
 
 struct Config {


### PR DESCRIPTION
## Summary
- remove no-op PlayerState::free_ngram and its kernel calls

## Testing
- `python -m pre_commit run --files damnati.cu`
- `nvcc -O3 -arch=sm_86 damnati.cu -o damnati` *(fails: command not found; attempted `apt-get install -y nvidia-cuda-toolkit` but installation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c811e8919483289c1918ceb345a0a3