### PR TITLE
Replace sqrt/floor pair mapping with integer arithmetic

### DIFF
--- a/damnati.cu
+++ b/damnati.cu
@@ -214,8 +214,7 @@ __global__ void play_all_pairs(const AgentParams *__restrict__ params,
   // the agent indices (i,j) from the linear pair index `idx` without
   // resorting to floating-point math.  The discriminant inside the square
   // root fits in 64 bits for practical `n_agents`.
-  long long disc =
-      -8LL * idx + 4LL * n_agents * (n_agents - 1) - 7LL;
+  long long disc = -8LL * idx + 4LL * n_agents * (n_agents - 1) - 7LL;
   long long s = isqrt64(disc);
   int i = (int)(n_agents - 2 - ((s - 1) >> 1));
   long long start = (long long)i * (2LL * n_agents - i - 1) / 2;

--- a/damnati.cu
+++ b/damnati.cu
@@ -56,6 +56,25 @@ __device__ __host__ __forceinline__ T dclamp(T v, T lo, T hi) {
   return v < lo ? lo : (v > hi ? hi : v);
 }
 
+// Integer square root using the non-restoring method.
+// Returns floor(sqrt(x)) for 0 <= x < 2^63.
+__device__ __host__ __forceinline__ long long isqrt64(long long x) {
+  long long res = 0;
+  long long bit = 1LL << 62; // Start at the highest power-of-four <= x (4^31)
+  while (bit > x)
+    bit >>= 2;
+  while (bit != 0) {
+    if (x >= res + bit) {
+      x -= res + bit;
+      res = (res >> 1) + bit;
+    } else {
+      res >>= 1;
+    }
+    bit >>= 2;
+  }
+  return res;
+}
+
 struct AgentParams {
   int strat;        // Strategy enum
   float epsilon;    // N-gram ε
@@ -191,9 +210,14 @@ __global__ void play_all_pairs(const AgentParams *__restrict__ params,
   if (idx >= total)
     return;
 
-  double disc =
-      sqrt((double)(-8LL * idx + 4LL * n_agents * (n_agents - 1) - 7));
-  int i = (int)(n_agents - 2 - floor((disc - 1.0) * 0.5));
+  // Invert the triangular number T(i) = i*(2n - i - 1)/2 to recover
+  // the agent indices (i,j) from the linear pair index `idx` without
+  // resorting to floating-point math.  The discriminant inside the square
+  // root fits in 64 bits for practical `n_agents`.
+  long long disc =
+      -8LL * idx + 4LL * n_agents * (n_agents - 1) - 7LL;
+  long long s = isqrt64(disc);
+  int i = (int)(n_agents - 2 - ((s - 1) >> 1));
   long long start = (long long)i * (2LL * n_agents - i - 1) / 2;
   int j = (int)(i + 1 + (idx - start));
 


### PR DESCRIPTION
## Summary
- add integer `isqrt64` helper for 64-bit square roots
- remove floating-point sqrt/floor in pair mapping and derive `(i,j)` via integer math

## Testing
- `python3 - <<'PY'
import math

def old_mapping(idx, n):
    disc = math.sqrt(-8*idx + 4*n*(n-1) - 7)
    i = int(n - 2 - math.floor((disc - 1)/2))
    start = i*(2*n - i -1)//2
    j = int(i + 1 + (idx - start))
    return i,j

def isqrt64(x):
    res = 0
    bit = 1 << 62
    while bit > x:
        bit >>= 2
    while bit:
        if x >= res + bit:
            x -= res + bit
            res = (res >> 1) + bit
        else:
            res >>= 1
        bit >>= 2
    return res

def new_mapping(idx, n):
    disc = -8*idx + 4*n*(n-1) - 7
    s = isqrt64(disc)
    i = n - 2 - ((s - 1) >> 1)
    start = i*(2*n - i - 1)//2
    j = i + 1 + (idx - start)
    return i,j

for n in [2,3,4,5,10,100,500,1000]:
    total = n*(n-1)//2
    for idx in range(total):
        if old_mapping(idx,n) != new_mapping(idx,n):
            print('mismatch', n, idx, old_mapping(idx,n), new_mapping(idx,n))
            raise SystemExit
print('all match for selected n values')
PY`
- `nvcc -O3 -arch=sm_52 damnati.cu -o damnati`
- `./damnati --agents 8 --rounds 5 --seed 42 --p-ngram 0.6` *(fails: no CUDA-capable device is detected)*

------
https://chatgpt.com/codex/tasks/task_e_68c811f09adc832890c47ab5f975029e