### PR TITLE
Enforce maximum N-gram depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,12 @@ Run the simulator and adjust parameters using command line flags:
 - `--rounds R`   – number of rounds per match (default: 200)
 - `--seed S`     – RNG seed (default: 1234567)
 - `--p-ngram F`  – fraction of agents using the N-gram strategy (default: 0.5)
-- `--depth D`    – N-gram history depth (default: 3)
+- `--depth D`    – N-gram history depth (default: 3, maximum: 15)
 - `--epsilon E`  – exploration rate for N-gram learners (default: 0.1)
 - `--gtft P`     – forgiveness probability for Generous Tit for Tat (default: 0.1)
+
+Depths above 15 are rejected to keep GPU memory allocations within practical
+limits.
 
 ## Output
 

--- a/damnati.cu
+++ b/damnati.cu
@@ -265,6 +265,8 @@ __global__ void play_all_pairs(const AgentParams *__restrict__ params,
   atomicAdd(&scores[j], scoreB);
 }
 
+constexpr int MAX_NGRAM_DEPTH = 15;
+
 struct Config {
   int n_agents = 256;
   int rounds = 200;
@@ -316,8 +318,9 @@ void parse_cli(int argc, char **argv, Config &cfg) {
       break;
     case 'd':
       cfg.depth = std::atoi(optarg);
-      if (cfg.depth < 0) {
-        std::fprintf(stderr, "Error: --depth must be non-negative.\n");
+      if (cfg.depth < 0 || cfg.depth > MAX_NGRAM_DEPTH) {
+        std::fprintf(stderr, "Error: --depth must be in [0,%d].\n",
+                     MAX_NGRAM_DEPTH);
         std::exit(EXIT_FAILURE);
       }
       break;
@@ -342,7 +345,7 @@ void parse_cli(int argc, char **argv, Config &cfg) {
       std::printf("  --rounds R    rounds per match (>0)\n");
       std::printf("  --seed S      RNG seed\n");
       std::printf("  --p-ngram F   fraction of N-gram learners [0,1]\n");
-      std::printf("  --depth D     N-gram depth (>=0)\n");
+      std::printf("  --depth D     N-gram depth (0-%d)\n", MAX_NGRAM_DEPTH);
       std::printf("  --epsilon E   exploration rate [0,1]\n");
       std::printf("  --gtft P      GTFT forgiveness [0,1]\n");
       std::printf("\nExample:\n  %s --agents 512 --rounds 200 --p-ngram 0.6 "


### PR DESCRIPTION
## Summary
- enforce a maximum allowed N-gram depth via a shared constant and CLI validation
- update the CLI help text and README to document the new depth ceiling

## Testing
- nvcc -std=c++17 tests/test_core.cu -o tests/test_core && ./tests/test_core *(fails: `nvcc` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c94f3066fc83289ec6ef8889defda5