### PR TITLE
Fix JSON formatting in run_gpu by_strategy output

### DIFF
--- a/damnati.cu
+++ b/damnati.cu
@@ -501,12 +501,16 @@ void run_gpu(const Config &cfg) {
   const char *names[] = {"AC",     "AD",     "TFT",  "GTFT", "GRIM",
                          "RANDOM", "PAVLOV", "ALT",  "JOSS", "TESTER",
                          "REPEAT", "S_TFT",  "NGRAM"};
+  bool first = true;
   for (int s = 0; s <= NGRAM; ++s) {
     if (cnt_by[s] == 0)
       continue;
-    std::printf("\"%s\":{\"mean\":%.3f,\"count\":%d}%s", names[s],
-                sum_by[s] / (double)dmax(1, cnt_by[s]), cnt_by[s],
-                (s == NGRAM ? "" : ","));
+    if (!first) {
+      std::printf(",");
+    }
+    std::printf("\"%s\":{\"mean\":%.3f,\"count\":%d}", names[s],
+                sum_by[s] / (double)dmax(1, cnt_by[s]), cnt_by[s]);
+    first = false;
   }
   std::printf("}}\n");
 


### PR DESCRIPTION
## Summary
- add a `first` flag when emitting `by_strategy` entries in `run_gpu`
- emit commas only between entries so the JSON formatter never adds a trailing comma

## Testing
- python - <<'PY'
import json
sample = '{"agents":4,"rounds":10,"p_ngram":0.500,"depth":2,"epsilon":0.050,\n "avg_score":1.234,"min":-2,"max":5,"stdev":0.321,\n "by_strategy":{"AC":{"mean":3.000,"count":1},"NGRAM":{"mean":2.000,"count":3}}}'
json.loads(sample)
print('valid')
PY

------
https://chatgpt.com/codex/tasks/task_e_68c94f529860832890fa337ed903519d