### PR TITLE
Add CLI validation tests and enhance README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,18 @@ Unit tests use the [Catch2](https://github.com/catchorg/Catch2) framework and ca
 compiled with `nvcc`. From the repository root run:
 
 ```bash
-nvcc -std=c++17 tests/test_core.cu -o tests/test_core && ./tests/test_core
+nvcc -std=c++17 tests/test_core.cu -o tests/test_core
+nvcc -std=c++17 tests/test_cli.cu -o tests/test_cli
 ```
 
-The tests cover strategy decision logic in `choose_action` and the payoff
-accumulation performed by `ngram_update`.
+Execute each binary to run the associated suite:
+
+```bash
+./tests/test_core
+./tests/test_cli
+```
+
+`test_core` exercises the strategy decision logic in `choose_action`, the payoff
+accumulation performed by `ngram_update`, and the 64-bit integer square root helper.
+`test_cli` verifies that command-line validation reports errors for malformed depth
+values and unknown options.

--- a/damnati.cu
+++ b/damnati.cu
@@ -9,6 +9,8 @@
 #include <cstring>
 #include <cuda_runtime.h>
 #include <getopt.h>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 #define CUDA_CHECK(call)                                                       \
@@ -287,21 +289,21 @@ void parse_cli(int argc, char **argv, Config &cfg) {
       {"help", no_argument, nullptr, 'h'},
       {nullptr, 0, nullptr, 0}};
 
+  opterr = 0;
+  optind = 1;
   int opt;
   while ((opt = getopt_long(argc, argv, "", long_opts, nullptr)) != -1) {
     switch (opt) {
     case 'a':
       cfg.n_agents = std::atoi(optarg);
       if (cfg.n_agents <= 0) {
-        std::fprintf(stderr, "Error: --agents must be positive.\n");
-        std::exit(EXIT_FAILURE);
+        throw std::runtime_error("Error: --agents must be positive.");
       }
       break;
     case 'r':
       cfg.rounds = std::atoi(optarg);
       if (cfg.rounds <= 0) {
-        std::fprintf(stderr, "Error: --rounds must be positive.\n");
-        std::exit(EXIT_FAILURE);
+        throw std::runtime_error("Error: --rounds must be positive.");
       }
       break;
     case 's':
@@ -310,29 +312,25 @@ void parse_cli(int argc, char **argv, Config &cfg) {
     case 'p':
       cfg.p_ngram = std::atof(optarg);
       if (cfg.p_ngram < 0.0f || cfg.p_ngram > 1.0f) {
-        std::fprintf(stderr, "Error: --p-ngram must be in [0,1].\n");
-        std::exit(EXIT_FAILURE);
+        throw std::runtime_error("Error: --p-ngram must be in [0,1].");
       }
       break;
     case 'd':
       cfg.depth = std::atoi(optarg);
       if (cfg.depth < 0) {
-        std::fprintf(stderr, "Error: --depth must be non-negative.\n");
-        std::exit(EXIT_FAILURE);
+        throw std::runtime_error("Error: --depth must be non-negative.");
       }
       break;
     case 'e':
       cfg.epsilon = std::atof(optarg);
       if (cfg.epsilon < 0.0f || cfg.epsilon > 1.0f) {
-        std::fprintf(stderr, "Error: --epsilon must be in [0,1].\n");
-        std::exit(EXIT_FAILURE);
+        throw std::runtime_error("Error: --epsilon must be in [0,1].");
       }
       break;
     case 'g':
       cfg.gtft_p = std::atof(optarg);
       if (cfg.gtft_p < 0.0f || cfg.gtft_p > 1.0f) {
-        std::fprintf(stderr, "Error: --gtft must be in [0,1].\n");
-        std::exit(EXIT_FAILURE);
+        throw std::runtime_error("Error: --gtft must be in [0,1].");
       }
       break;
     case 'h':
@@ -349,8 +347,16 @@ void parse_cli(int argc, char **argv, Config &cfg) {
                   "--depth 3 --epsilon 0.1 --gtft 0.2\n",
                   argv[0]);
       std::exit(0);
+    case '?': {
+      std::string flag =
+          (optind > 0 && optind - 1 < argc) ? std::string(argv[optind - 1])
+                                            : std::string();
+      if (!flag.empty())
+        throw std::runtime_error("Error: unrecognized option '" + flag + "'.");
+      throw std::runtime_error("Error: unrecognized option.");
+    }
     default:
-      break;
+      throw std::runtime_error("Error: unrecognized option.");
     }
   }
 }
@@ -527,7 +533,12 @@ void run_gpu(const Config &cfg) {
 #ifndef DAMNATI_NO_MAIN
 int main(int argc, char **argv) {
   Config cfg;
-  parse_cli(argc, argv, cfg);
+  try {
+    parse_cli(argc, argv, cfg);
+  } catch (const std::exception &ex) {
+    std::fprintf(stderr, "%s\n", ex.what());
+    return EXIT_FAILURE;
+  }
   run_gpu(cfg);
   return 0;
 }

--- a/tests/test_cli.cu
+++ b/tests/test_cli.cu
@@ -1,0 +1,36 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#define DAMNATI_NO_MAIN
+#include "../damnati.cu"
+
+TEST_CASE("parse_cli rejects invalid depth and unknown options", "[cli]") {
+  Config cfg;
+
+  {
+    char prog[] = "damnati";
+    char depth[] = "--depth";
+    char neg[] = "-1";
+    char *argv[] = {prog, depth, neg, nullptr};
+    int argc = 3;
+    try {
+      parse_cli(argc, argv, cfg);
+      FAIL("parse_cli should have thrown for negative depth");
+    } catch (const std::runtime_error &ex) {
+      REQUIRE(std::string(ex.what()) == "Error: --depth must be non-negative.");
+    }
+  }
+
+  {
+    char prog[] = "damnati";
+    char unknown[] = "--unknown";
+    char *argv[] = {prog, unknown, nullptr};
+    int argc = 2;
+    try {
+      parse_cli(argc, argv, cfg);
+      FAIL("parse_cli should have thrown for unknown option");
+    } catch (const std::runtime_error &ex) {
+      REQUIRE(std::string(ex.what()).find("unrecognized option") != std::string::npos);
+    }
+  }
+}

--- a/tests/test_core.cu
+++ b/tests/test_core.cu
@@ -130,3 +130,28 @@ TEST_CASE("ngram_update accumulates payoffs", "[ngram]") {
   REQUIRE(counts[0 * 2 + C] == 2);
   REQUIRE(q[0 * 2 + C] == Approx(2.0f));
 }
+
+TEST_CASE("isqrt64 computes floor square roots", "[isqrt64]") {
+  struct Case {
+    long long input;
+    long long expected;
+  };
+  const Case cases[] = {{0, 0},
+                        {1, 1},
+                        {2, 1},
+                        {3, 1},
+                        {4, 2},
+                        {7, 2},
+                        {8, 2},
+                        {15, 3},
+                        {16, 4},
+                        {24, 4},
+                        {25, 5},
+                        {(1LL << 62) - 1, 2147483647LL},
+                        {(1LL << 62), 2147483648LL}};
+
+  for (const auto &c : cases) {
+    CAPTURE(c.input);
+    REQUIRE(isqrt64(c.input) == c.expected);
+  }
+}


### PR DESCRIPTION
## Summary
- switch CLI validation to throw exceptions for invalid arguments and unknown options while keeping runtime error reporting in `main`
- add Catch2 coverage for the integer square root helper and CLI parsing edge cases
- update the README with build and execution steps for the expanded test suite

## Testing
- `nvcc -std=c++17 tests/test_core.cu -o tests/test_core` *(fails: `nvcc` not available in the execution environment)*
- `nvcc -std=c++17 tests/test_cli.cu -o tests/test_cli` *(fails: `nvcc` not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c94f5918908328835ab1434d8122dc