### PR TITLE
Simplify build_population shuffling logic

### DIFF
--- a/damnati.cu
+++ b/damnati.cu
@@ -402,14 +402,8 @@ void build_population(const Config &cfg, std::vector<AgentParams> &hparams) {
     hparams[i] = p;
   }
 
-  std::vector<int> idx(n);
-  for (int i = 0; i < n; ++i)
-    idx[i] = i;
   std::mt19937_64 rng(cfg.seed);
-  std::shuffle(idx.begin(), idx.end(), rng);
-  std::vector<AgentParams> copy = hparams;
-  for (int i = 0; i < n; ++i)
-    hparams[i] = copy[idx[i]];
+  std::shuffle(hparams.begin(), hparams.end(), rng);
 }
 
 void run_gpu(const Config &cfg) {


### PR DESCRIPTION
## Summary
- shuffle agent parameters in place when building the population instead of using an auxiliary index vector

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c97f624f70832890529c9a6989cc94