### PR TITLE
Add defensive default in choose_action

### DIFF
--- a/damnati.cu
+++ b/damnati.cu
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cassert>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -200,8 +201,10 @@ choose_action(PlayerState &p, uint64_t seed, int i, int j, int r, int who) {
     return (p.opp_last == -1 ? D : p.opp_last);
   case NGRAM:
     return ngram_choose(p, seed, i, j, r, who);
+  default:
+    assert(!"Unknown strategy in choose_action");
+    return C;
   }
-  return C;
 }
 
 __global__ void play_all_pairs(const AgentParams *__restrict__ params,


### PR DESCRIPTION
## Summary
- include `<cassert>` so we can use runtime assertions
- add a default branch in `choose_action` that asserts on unknown strategies

## Testing
- `nvcc -std=c++17 tests/test_core.cu -o tests/test_core` *(fails: nvcc not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c97f81269083289467b0f733cadddc