### PR TITLE
Throw runtime errors for CLI validation

### DIFF
--- a/damnati.cu
+++ b/damnati.cu
@@ -317,8 +317,7 @@ void parse_cli(int argc, char **argv, Config &cfg) {
     case 'a':
       cfg.n_agents = std::atoi(optarg);
       if (cfg.n_agents < 2) {
-        std::fprintf(stderr, "Error: --agents must be at least 2.\n");
-        std::exit(EXIT_FAILURE);
+        throw std::runtime_error("Error: --agents must be at least 2.");
       }
       break;
     case 'r':
@@ -339,9 +338,8 @@ void parse_cli(int argc, char **argv, Config &cfg) {
     case 'd':
       cfg.depth = std::atoi(optarg);
       if (cfg.depth < 0 || cfg.depth > MAX_NGRAM_DEPTH) {
-        std::fprintf(stderr, "Error: --depth must be in [0,%d].\n",
-                     MAX_NGRAM_DEPTH);
-        std::exit(EXIT_FAILURE);
+        throw std::runtime_error(std::string("Error: --depth must be in [0,") +
+                                 std::to_string(MAX_NGRAM_DEPTH) + "].");
       }
       break;
     case 'e':

--- a/tests/test_cli.cu
+++ b/tests/test_cli.cu
@@ -17,7 +17,25 @@ TEST_CASE("parse_cli rejects invalid depth and unknown options", "[cli]") {
       parse_cli(argc, argv, cfg);
       FAIL("parse_cli should have thrown for negative depth");
     } catch (const std::runtime_error &ex) {
-      REQUIRE(std::string(ex.what()) == "Error: --depth must be non-negative.");
+      const std::string expected =
+          std::string("Error: --depth must be in [0,") +
+          std::to_string(MAX_NGRAM_DEPTH) + "].";
+      REQUIRE(std::string(ex.what()) == expected);
+    }
+  }
+
+  {
+    char prog[] = "damnati";
+    char agents[] = "--agents";
+    char one[] = "1";
+    char *argv[] = {prog, agents, one, nullptr};
+    int argc = 3;
+    try {
+      parse_cli(argc, argv, cfg);
+      FAIL("parse_cli should have thrown for too few agents");
+    } catch (const std::runtime_error &ex) {
+      REQUIRE(std::string(ex.what()) ==
+              "Error: --agents must be at least 2.");
     }
   }
 


### PR DESCRIPTION
## Summary
- replace the `--agents` and `--depth` validation logic in `parse_cli` to throw descriptive `std::runtime_error`s instead of exiting
- extend the CLI test suite to expect the new messages and cover the `--agents` failure case

## Testing
- `nvcc -std=c++17 tests/test_cli.cu -o tests/test_cli` *(fails: `nvcc` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c97f553db88328bfc968853904a930