### PR TITLE
Guard parse_cli against extra CLI arguments

### DIFF
--- a/damnati.cu
+++ b/damnati.cu
@@ -438,6 +438,11 @@ void parse_cli(int argc, char **argv, Config &cfg) {
       std::exit(EXIT_FAILURE);
     }
   }
+
+  if (optind < argc) {
+    throw std::runtime_error("Error: unexpected positional argument '" +
+                             std::string(argv[optind]) + "'.");
+  }
 }
 
 static const Strategy classics[12] = {AC,     AD,  TFT,  GTFT,   GRIM,   RANDOM,

--- a/tests/test_cli.cu
+++ b/tests/test_cli.cu
@@ -51,4 +51,18 @@ TEST_CASE("parse_cli rejects invalid depth and unknown options", "[cli]") {
               std::string::npos);
     }
   }
+
+  {
+    char prog[] = "damnati";
+    char token[] = "extra";
+    char *argv[] = {prog, token, nullptr};
+    int argc = 2;
+    try {
+      parse_cli(argc, argv, cfg);
+      FAIL("parse_cli should have thrown for unexpected positional argument");
+    } catch (const std::runtime_error &ex) {
+      REQUIRE(std::string(ex.what()) ==
+              "Error: unexpected positional argument 'extra'.");
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- throw a runtime_error when parse_cli encounters unexpected positional arguments
- extend the CLI test suite to cover the new error message

## Testing
- `nvcc -std=c++17 tests/test_cli.cu -o tests/test_cli` *(fails: `nvcc` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9bb9ee91c8328bfd817be836f27da