### PR TITLE
Use 64-bit score accumulation

### DIFF
--- a/tests/test_cli.cu
+++ b/tests/test_cli.cu
@@ -39,6 +39,17 @@ TEST_CASE("parse_cli rejects invalid depth and unknown options", "[cli]") {
   }
 
   {
+    cfg = Config{};
+    char prog[] = "damnati";
+    char rounds[] = "--rounds";
+    char big[] = "2000000000";
+    char *argv[] = {prog, rounds, big, nullptr};
+    int argc = 3;
+    REQUIRE_NOTHROW(parse_cli(argc, argv, cfg));
+    REQUIRE(cfg.rounds == 2000000000);
+  }
+
+  {
     char prog[] = "damnati";
     char unknown[] = "--unknown";
     char *argv[] = {prog, unknown, nullptr};


### PR DESCRIPTION
## Summary
- switch the GPU score buffers and accumulation to 64-bit integers
- update the host aggregation and reporting logic to use 64-bit-safe math and formatting
- extend the CLI test suite to cover very large --rounds values

## Testing
- nvcc -std=c++17 tests/test_cli.cu -o test_cli *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2cd6e244832889821cdad11b7374