### PR TITLE
Improve CLI missing argument handling

### DIFF
--- a/damnati.cu
+++ b/damnati.cu
@@ -408,7 +408,8 @@ void parse_cli(int argc, char **argv, Config &cfg) {
   opterr = 0;
   optind = 1;
   int opt;
-  while ((opt = getopt_long(argc, argv, "", long_opts, nullptr)) != -1) {
+  while ((opt = getopt_long(argc, argv, ":a:r:s:p:d:e:g:h", long_opts, nullptr)) !=
+         -1) {
     switch (opt) {
     case 'a':
       cfg.n_agents = parse_int_option("agents", optarg);
@@ -453,6 +454,43 @@ void parse_cli(int argc, char **argv, Config &cfg) {
     case 'h':
       print_usage(stdout, argv[0]);
       std::exit(0);
+    case ':': {
+      const char *flag_name = nullptr;
+      switch (optopt) {
+      case 'a':
+        flag_name = "--agents";
+        break;
+      case 'r':
+        flag_name = "--rounds";
+        break;
+      case 's':
+        flag_name = "--seed";
+        break;
+      case 'p':
+        flag_name = "--p-ngram";
+        break;
+      case 'd':
+        flag_name = "--depth";
+        break;
+      case 'e':
+        flag_name = "--epsilon";
+        break;
+      case 'g':
+        flag_name = "--gtft";
+        break;
+      default:
+        break;
+      }
+      std::string flag;
+      if (flag_name != nullptr) {
+        flag = flag_name;
+      } else if (optind > 0 && optind - 1 < argc) {
+        flag = argv[optind - 1];
+      } else {
+        flag = "option";
+      }
+      throw std::runtime_error("Error: " + flag + " requires a value.");
+    }
     case '?': {
       std::string flag = (optind > 0 && optind - 1 < argc)
                              ? std::string(argv[optind - 1])

--- a/tests/test_cli.cu
+++ b/tests/test_cli.cu
@@ -39,6 +39,21 @@ TEST_CASE("parse_cli rejects invalid depth and unknown options", "[cli]") {
   }
 
   {
+    char prog[] = "damnati";
+    char agents[] = "--agents";
+    char rounds[] = "--rounds";
+    char ten[] = "10";
+    char *argv[] = {prog, agents, rounds, ten, nullptr};
+    int argc = 4;
+    try {
+      parse_cli(argc, argv, cfg);
+      FAIL("parse_cli should have thrown for missing agents value");
+    } catch (const std::runtime_error &ex) {
+      REQUIRE(std::string(ex.what()) == "Error: --agents requires a value.");
+    }
+  }
+
+  {
     cfg = Config{};
     char prog[] = "damnati";
     char rounds[] = "--rounds";


### PR DESCRIPTION
## Summary
- configure getopt_long to surface missing argument errors and report which flag needs a value
- extend CLI unit tests to cover the new missing argument diagnostic

## Testing
- `nvcc -std=c++17 tests/test_cli.cu -o tests/test_cli` *(fails: nvcc not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d16676438c83288732a2d5bde4c11a