### PR TITLE
Sort agent reporting by score

### DIFF
--- a/tests/test_core.cu
+++ b/tests/test_core.cu
@@ -156,6 +156,22 @@ TEST_CASE("isqrt64 computes floor square roots", "[isqrt64]") {
   }
 }
 
+TEST_CASE("sorted_agent_scores orders by score then index", "[report]") {
+  const long long scores[] = {15, 42, 42, -3, 0};
+  auto ranked = sorted_agent_scores(scores, 5);
+  REQUIRE(ranked.size() == 5);
+  REQUIRE(ranked[0].first == 1);
+  REQUIRE(ranked[0].second == 42);
+  REQUIRE(ranked[1].first == 2);
+  REQUIRE(ranked[1].second == 42);
+  REQUIRE(ranked[2].first == 0);
+  REQUIRE(ranked[2].second == 15);
+  REQUIRE(ranked[3].first == 4);
+  REQUIRE(ranked[3].second == 0);
+  REQUIRE(ranked[4].first == 3);
+  REQUIRE(ranked[4].second == -3);
+}
+
 TEST_CASE("GPU tournament with multiple N-gram agents is deterministic",
           "[gpu]") {
   const int n_agents = 6;


### PR DESCRIPTION
## Summary
- add a helper to collect and sort agent indices by their tournament scores
- update GPU run reporting to use the sorted rankings so the highest scoring agents are printed first
- cover the ranking helper with a deterministic unit test to confirm ordering and tie breaking

## Testing
- `nvcc -std=c++17 tests/test_core.cu -o tests/test_core` *(fails: nvcc not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1666ed8b48328842053120a44d460