### PR TITLE
Guard GPU launch against oversized tournaments

### DIFF
--- a/tests/test_cli.cu
+++ b/tests/test_cli.cu
@@ -77,3 +77,19 @@ TEST_CASE("parse_cli rejects invalid depth and unknown options", "[cli]") {
     }
   }
 }
+
+TEST_CASE("run_gpu rejects tournaments that exceed launch capacity",
+          "[cli][limits]") {
+  Config cfg;
+  cfg.n_agents = 1048577;
+  cfg.p_ngram = 0.0f;
+  cfg.rounds = 1;
+
+  try {
+    run_gpu(cfg);
+    FAIL("run_gpu should have thrown for excessive tournament size");
+  } catch (const std::runtime_error &ex) {
+    REQUIRE(std::string(ex.what()).find("exceeding the maximum supported") !=
+            std::string::npos);
+  }
+}


### PR DESCRIPTION
## Summary
- add explicit checks in `run_gpu` to reject tournaments whose pair count or block count exceed supported GPU launch limits
- report configuration errors through exceptions that propagate to `main` for graceful CLI diagnostics
- cover the new guard with a regression test that exercises an oversized configuration

## Testing
- `nvcc -std=c++17 tests/test_core.cu -o tests/test_core` *(fails: nvcc not installed in environment)*
- `nvcc -std=c++17 tests/test_cli.cu -o tests/test_cli` *(fails: nvcc not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d16675d57c8328a38a4207a15a252c