### PR TITLE
Enhance parse_cli boundary and seed validation tests

### DIFF
--- a/tests/test_cli.cu
+++ b/tests/test_cli.cu
@@ -5,9 +5,8 @@
 #include "../damnati.cu"
 
 TEST_CASE("parse_cli rejects invalid depth and unknown options", "[cli]") {
-  Config cfg;
-
   {
+    Config cfg{};
     char prog[] = "damnati";
     char depth[] = "--depth";
     char neg[] = "-1";
@@ -25,6 +24,7 @@ TEST_CASE("parse_cli rejects invalid depth and unknown options", "[cli]") {
   }
 
   {
+    Config cfg{};
     char prog[] = "damnati";
     char agents[] = "--agents";
     char one[] = "1";
@@ -39,6 +39,7 @@ TEST_CASE("parse_cli rejects invalid depth and unknown options", "[cli]") {
   }
 
   {
+    Config cfg{};
     char prog[] = "damnati";
     char agents[] = "--agents";
     char rounds[] = "--rounds";
@@ -54,7 +55,7 @@ TEST_CASE("parse_cli rejects invalid depth and unknown options", "[cli]") {
   }
 
   {
-    cfg = Config{};
+    Config cfg{};
     char prog[] = "damnati";
     char rounds[] = "--rounds";
     char big[] = "2000000000";
@@ -65,6 +66,7 @@ TEST_CASE("parse_cli rejects invalid depth and unknown options", "[cli]") {
   }
 
   {
+    Config cfg{};
     char prog[] = "damnati";
     char unknown[] = "--unknown";
     char *argv[] = {prog, unknown, nullptr};
@@ -79,6 +81,7 @@ TEST_CASE("parse_cli rejects invalid depth and unknown options", "[cli]") {
   }
 
   {
+    Config cfg{};
     char prog[] = "damnati";
     char token[] = "extra";
     char *argv[] = {prog, token, nullptr};
@@ -89,6 +92,210 @@ TEST_CASE("parse_cli rejects invalid depth and unknown options", "[cli]") {
     } catch (const std::runtime_error &ex) {
       REQUIRE(std::string(ex.what()) ==
               "Error: unexpected positional argument 'extra'.");
+    }
+  }
+}
+
+TEST_CASE("parse_cli validates boundary values for depth and probabilities",
+          "[cli]") {
+  {
+    Config cfg{};
+    char prog[] = "damnati";
+    char depth[] = "--depth";
+    char zero[] = "0";
+    char *argv[] = {prog, depth, zero, nullptr};
+    int argc = 3;
+    REQUIRE_NOTHROW(parse_cli(argc, argv, cfg));
+    REQUIRE(cfg.depth == 0);
+  }
+
+  {
+    Config cfg{};
+    char prog[] = "damnati";
+    char depth[] = "--depth";
+    char max_depth[] = "15";
+    char *argv[] = {prog, depth, max_depth, nullptr};
+    int argc = 3;
+    REQUIRE_NOTHROW(parse_cli(argc, argv, cfg));
+    REQUIRE(cfg.depth == MAX_NGRAM_DEPTH);
+  }
+
+  {
+    Config cfg{};
+    char prog[] = "damnati";
+    char depth[] = "--depth";
+    char too_large[] = "16";
+    char *argv[] = {prog, depth, too_large, nullptr};
+    int argc = 3;
+    try {
+      parse_cli(argc, argv, cfg);
+      FAIL("parse_cli should have thrown for depth above max");
+    } catch (const std::runtime_error &ex) {
+      REQUIRE(std::string(ex.what()) ==
+              "Error: --depth must be in [0,15].");
+    }
+  }
+
+  {
+    Config cfg{};
+    char prog[] = "damnati";
+    char epsilon[] = "--epsilon";
+    char zero[] = "0";
+    char *argv[] = {prog, epsilon, zero, nullptr};
+    int argc = 3;
+    REQUIRE_NOTHROW(parse_cli(argc, argv, cfg));
+    REQUIRE(cfg.epsilon == Approx(0.0f));
+  }
+
+  {
+    Config cfg{};
+    char prog[] = "damnati";
+    char epsilon[] = "--epsilon";
+    char one[] = "1";
+    char *argv[] = {prog, epsilon, one, nullptr};
+    int argc = 3;
+    REQUIRE_NOTHROW(parse_cli(argc, argv, cfg));
+    REQUIRE(cfg.epsilon == Approx(1.0f));
+  }
+
+  {
+    Config cfg{};
+    char prog[] = "damnati";
+    char epsilon[] = "--epsilon";
+    char below[] = "-0.01";
+    char *argv[] = {prog, epsilon, below, nullptr};
+    int argc = 3;
+    REQUIRE_THROWS_WITH(parse_cli(argc, argv, cfg),
+                        "Error: --epsilon must be in [0,1].");
+  }
+
+  {
+    Config cfg{};
+    char prog[] = "damnati";
+    char epsilon[] = "--epsilon";
+    char above[] = "1.01";
+    char *argv[] = {prog, epsilon, above, nullptr};
+    int argc = 3;
+    REQUIRE_THROWS_WITH(parse_cli(argc, argv, cfg),
+                        "Error: --epsilon must be in [0,1].");
+  }
+
+  {
+    Config cfg{};
+    char prog[] = "damnati";
+    char pngram[] = "--p-ngram";
+    char zero[] = "0";
+    char *argv[] = {prog, pngram, zero, nullptr};
+    int argc = 3;
+    REQUIRE_NOTHROW(parse_cli(argc, argv, cfg));
+    REQUIRE(cfg.p_ngram == Approx(0.0f));
+  }
+
+  {
+    Config cfg{};
+    char prog[] = "damnati";
+    char pngram[] = "--p-ngram";
+    char one[] = "1";
+    char *argv[] = {prog, pngram, one, nullptr};
+    int argc = 3;
+    REQUIRE_NOTHROW(parse_cli(argc, argv, cfg));
+    REQUIRE(cfg.p_ngram == Approx(1.0f));
+  }
+
+  {
+    Config cfg{};
+    char prog[] = "damnati";
+    char pngram[] = "--p-ngram";
+    char below[] = "-0.01";
+    char *argv[] = {prog, pngram, below, nullptr};
+    int argc = 3;
+    REQUIRE_THROWS_WITH(parse_cli(argc, argv, cfg),
+                        "Error: --p-ngram must be in [0,1].");
+  }
+
+  {
+    Config cfg{};
+    char prog[] = "damnati";
+    char pngram[] = "--p-ngram";
+    char above[] = "1.01";
+    char *argv[] = {prog, pngram, above, nullptr};
+    int argc = 3;
+    REQUIRE_THROWS_WITH(parse_cli(argc, argv, cfg),
+                        "Error: --p-ngram must be in [0,1].");
+  }
+
+  {
+    Config cfg{};
+    char prog[] = "damnati";
+    char gtft[] = "--gtft";
+    char zero[] = "0";
+    char *argv[] = {prog, gtft, zero, nullptr};
+    int argc = 3;
+    REQUIRE_NOTHROW(parse_cli(argc, argv, cfg));
+    REQUIRE(cfg.gtft_p == Approx(0.0f));
+  }
+
+  {
+    Config cfg{};
+    char prog[] = "damnati";
+    char gtft[] = "--gtft";
+    char one[] = "1";
+    char *argv[] = {prog, gtft, one, nullptr};
+    int argc = 3;
+    REQUIRE_NOTHROW(parse_cli(argc, argv, cfg));
+    REQUIRE(cfg.gtft_p == Approx(1.0f));
+  }
+
+  {
+    Config cfg{};
+    char prog[] = "damnati";
+    char gtft[] = "--gtft";
+    char below[] = "-0.01";
+    char *argv[] = {prog, gtft, below, nullptr};
+    int argc = 3;
+    REQUIRE_THROWS_WITH(parse_cli(argc, argv, cfg),
+                        "Error: --gtft must be in [0,1].");
+  }
+
+  {
+    Config cfg{};
+    char prog[] = "damnati";
+    char gtft[] = "--gtft";
+    char above[] = "1.01";
+    char *argv[] = {prog, gtft, above, nullptr};
+    int argc = 3;
+    REQUIRE_THROWS_WITH(parse_cli(argc, argv, cfg),
+                        "Error: --gtft must be in [0,1].");
+  }
+}
+
+TEST_CASE("parse_cli validates seed parsing failures", "[cli]") {
+  {
+    Config cfg{};
+    char prog[] = "damnati";
+    char seed[] = "--seed";
+    char overflow[] = "18446744073709551616";
+    char *argv[] = {prog, seed, overflow, nullptr};
+    int argc = 3;
+    REQUIRE_THROWS_WITH(parse_cli(argc, argv, cfg),
+                        "Error: value for --seed is out of range: "
+                        "'18446744073709551616'.");
+  }
+
+  {
+    Config cfg{};
+    char prog[] = "damnati";
+    char seed[] = "--seed";
+    char invalid[] = "123abc";
+    char *argv[] = {prog, seed, invalid, nullptr};
+    int argc = 3;
+    try {
+      parse_cli(argc, argv, cfg);
+      FAIL("parse_cli should have thrown for invalid seed token");
+    } catch (const std::runtime_error &ex) {
+      REQUIRE(std::string(ex.what()).find("invalid value for --seed") !=
+              std::string::npos);
+      REQUIRE(std::string(ex.what()).find("123abc") != std::string::npos);
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Improve unit test coverage for `parse_cli` around valid boundary values and invalid boundary-adjacent inputs for CLI options.
- Exercise `parse_uint64_option` by adding overflow and invalid-token `--seed` cases.
- Eliminate cross-test state contamination by ensuring every case uses a fresh `Config{}` instance.
- Assert exact error messages where deterministic and use substring checks where platform parsing text may vary.

### Description
- Updated `tests/test_cli.cu` to instantiate `Config{}` in each subcase to avoid state bleed between assertions.
- Added a new `TEST_CASE` `parse_cli validates boundary values for depth and probabilities` that covers valid endpoints and adjacent invalids for `--depth`, `--epsilon`, `--p-ngram`, and `--gtft`, using `REQUIRE_NOTHROW`, `REQUIRE_THROWS_WITH`, and `Approx` for float checks.
- Added a new `TEST_CASE` `parse_cli validates seed parsing failures` that covers a uint64 overflow input and an invalid-token input for `--seed`, asserting exact overflow error text and substring matches for the invalid token case.
- Kept assertions precise: exact message comparisons where stable and substring matches where parsing diagnostics may vary across platforms.

### Testing
- Attempted to compile the CLI tests with `nvcc -std=c++17 tests/test_cli.cu -o tests/test_cli`, but the attempt failed in this environment because `nvcc` is not installed (error: `nvcc: command not found`).
- No automated test run was executed here; changes are limited to `tests/test_cli.cu` and are ready for CI to compile and run the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d177825f308328a3d33ce2362caf22)